### PR TITLE
Improve wording for clarity in SQL Syntax documentation

### DIFF
--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -15,11 +15,11 @@
  </para>
 
  <para>
-  We also advise users who are already familiar with SQL to read this
-  chapter carefully because it contains several rules and concepts that
-  are implemented inconsistently among SQL databases or that are
-  specific to <productname>PostgreSQL</productname>.
- </para>
+ We also encourage users who are already familiar with SQL to read this
+ chapter carefully, as it contains several rules and concepts that
+ are implemented inconsistently among SQL databases or are
+ specific to <productname>PostgreSQL</productname>.
+</para>
 
  <sect1 id="sql-syntax-lexical">
   <title>Lexical Structure</title>

--- a/doc/src/sgml/syntax.sgml
+++ b/doc/src/sgml/syntax.sgml
@@ -18,7 +18,7 @@
  We also encourage users who are already familiar with SQL to read this
  chapter carefully, as it contains several rules and concepts that
  are implemented inconsistently among SQL databases or are
- specific to <productname>PostgreSQL</productname>.
+ specific to the <productname>PostgreSQL</productname>.
 </para>
 
  <sect1 id="sql-syntax-lexical">


### PR DESCRIPTION
This pull request improves the wording for better clarity and flow in the SQL Syntax documentation chapter. 
No functional changes were made.
